### PR TITLE
fix(callout-http): Do not verify host when doing https call

### DIFF
--- a/src/main/java/io/gravitee/policy/callout/CalloutHttpPolicy.java
+++ b/src/main/java/io/gravitee/policy/callout/CalloutHttpPolicy.java
@@ -147,7 +147,9 @@ public class CalloutHttpPolicy {
 
             HttpClientOptions options = new HttpClientOptions();
             if (HTTPS_SCHEME.equalsIgnoreCase(target.getScheme())) {
-                options.setSsl(true).setTrustAll(true);
+                options.setSsl(true)
+                        .setTrustAll(true)
+                        .setVerifyHost(false);
             }
 
             HttpClient httpClient = vertx.createHttpClient(options);


### PR DESCRIPTION
Closes gravitee-io/issues#4191