### PR TITLE
Creating connection and read time outs with ignore time outs exceptions option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,6 +55,18 @@ execution. If no variable has been configured the result of the callout will not
 ^.^|URL
 ^.^|-
 
+.^|conTimeout
+^.^|X
+|Connection Timeout (ms)
+^.^|int
+^.^|1000
+
+.^|readTimeout
+^.^|X
+|Read Timeout (ms)
+^.^|int
+^.^|5000
+
 .^|headers
 ^.^|X
 |List of HTTP headers used to invoke the URL (support EL)
@@ -72,6 +84,12 @@ execution. If no variable has been configured the result of the callout will not
 |The variables to set in the execution context when retrieving content of HTTP call (support EL)
 ^.^|List of variables
 ^.^|-
+
+.^|continueOnTimeout
+^.^|X
+|Ignore Timeouts and continue the flow
+^.^|boolean
+^.^|false
 
 .^|exitOnError
 ^.^|X
@@ -105,6 +123,8 @@ execution. If no variable has been configured the result of the callout will not
 "policy-http-callout": {
     "method": "GET",
     "url": "https://api.gravitee.io/echo",
+    "conTimeout": 1000,
+    "readTimeout": 5000,
     "headers": [ {
         "name": "X-Gravitee-Request-Id",
         "value": "{#request.id}"

--- a/src/main/java/io/gravitee/policy/callout/CalloutHttpPolicy.java
+++ b/src/main/java/io/gravitee/policy/callout/CalloutHttpPolicy.java
@@ -269,7 +269,7 @@ public class CalloutHttpPolicy {
                     }).exceptionHandler(throwable -> {
 
                         // exit and validate ExitOnError only if ignore exceptions are false
-                        if (!configuration.ignoreTimeouts()) {
+                        if (!configuration.isContinueOnTimeout()) {
                             // exit chain only if policy ask not ExitOnError
                             if (configuration.isExitOnError()) {
                                 onError.accept(PolicyResult.failure(CALLOUT_HTTP_ERROR, throwable.getMessage()));

--- a/src/main/java/io/gravitee/policy/callout/configuration/CalloutHttpPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/callout/configuration/CalloutHttpPolicyConfiguration.java
@@ -74,6 +74,12 @@ public class CalloutHttpPolicyConfiguration implements PolicyConfiguration {
         this.url = url;
     }
 
+    private String conTimeout;
+
+    private String readTimeout;
+
+    private boolean ignoreExceptions;
+
     public List<HttpHeader> getHeaders() {
         return headers;
     }
@@ -136,5 +142,29 @@ public class CalloutHttpPolicyConfiguration implements PolicyConfiguration {
 
     public void setErrorContent(String errorContent) {
         this.errorContent = errorContent;
+    }
+
+    public String getConTimeout() {
+        return conTimeout;
+    }
+
+    public void setConTimeout(String conTimeout) {
+        this.conTimeout = conTimeout;
+    }
+
+    public String getReadTimeout() {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(String readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    public boolean ignoreTimeouts() {
+        return ignoreExceptions;
+    }
+
+    public void setIgnoreExceptions(boolean ignoreExceptions) {
+        this.ignoreExceptions = ignoreExceptions;
     }
 }

--- a/src/main/java/io/gravitee/policy/callout/configuration/CalloutHttpPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/callout/configuration/CalloutHttpPolicyConfiguration.java
@@ -78,7 +78,7 @@ public class CalloutHttpPolicyConfiguration implements PolicyConfiguration {
 
     private String readTimeout;
 
-    private boolean ignoreExceptions;
+    private boolean continueOnTimeout;
 
     public List<HttpHeader> getHeaders() {
         return headers;
@@ -160,11 +160,11 @@ public class CalloutHttpPolicyConfiguration implements PolicyConfiguration {
         this.readTimeout = readTimeout;
     }
 
-    public boolean ignoreTimeouts() {
-        return ignoreExceptions;
+    public boolean isContinueOnTimeout() {
+        return continueOnTimeout;
     }
 
-    public void setIgnoreExceptions(boolean ignoreExceptions) {
-        this.ignoreExceptions = ignoreExceptions;
+    public void setContinueOnTimeout(boolean continueOnTimeout) {
+        this.continueOnTimeout = continueOnTimeout;
     }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -26,6 +26,16 @@
       "title": "URL",
       "type" : "string"
     },
+    "conTimeout": {
+      "title": "Connection Timeout (ms)",
+      "default": 1000,
+      "type" : "number"
+    },
+    "readTimeout": {
+      "title": "Read Timeout (ms)",
+      "default": 5000,
+      "type" : "number"
+    },
     "headers" : {
       "type" : "array",
       "title": "Request Headers",
@@ -86,6 +96,12 @@
         "name",
         "value"
       ]
+    },
+    "ignoreExceptions": {
+      "title": "Ignore Timeouts",
+      "description": "Ignore Timeouts Exceptions in cases that it's needed",
+      "type" : "boolean",
+      "default": false
     },
     "exitOnError": {
       "title": "Exit on error",

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -29,12 +29,14 @@
     "conTimeout": {
       "title": "Connection Timeout (ms)",
       "default": 1000,
-      "type" : "number"
+      "type" : "integer",
+      "minimum": 0
     },
     "readTimeout": {
       "title": "Read Timeout (ms)",
       "default": 5000,
-      "type" : "number"
+      "type" : "integer",
+      "minimum": 0
     },
     "headers" : {
       "type" : "array",
@@ -97,8 +99,8 @@
         "value"
       ]
     },
-    "ignoreExceptions": {
-      "title": "Ignore Timeouts",
+    "continueOnTimeout": {
+      "title": "Ignore Timeouts and continue the flow",
       "description": "Ignore Timeouts Exceptions in cases that it's needed",
       "type" : "boolean",
       "default": false

--- a/src/test/java/io/gravitee/policy/CalloutHttpPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/CalloutHttpPolicyTest.java
@@ -110,6 +110,8 @@ public class CalloutHttpPolicyTest {
 
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
         when(configuration.getUrl()).thenReturn(invalidTarget);
+        when(configuration.getConTimeout()).thenReturn("1000");
+        when(configuration.getReadTimeout()).thenReturn("1000");
 
         final CountDownLatch lock = new CountDownLatch(1);
         this.policyChain = spy(new CountDownPolicyChain(lock));
@@ -131,6 +133,8 @@ public class CalloutHttpPolicyTest {
 
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
         when(configuration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/");
+        when(configuration.getConTimeout()).thenReturn("1000");
+        when(configuration.getReadTimeout()).thenReturn("1000");
 
         final CountDownLatch lock = new CountDownLatch(1);
         this.policyChain = spy(new CountDownPolicyChain(lock));
@@ -154,6 +158,8 @@ public class CalloutHttpPolicyTest {
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
         when(configuration.isUseSystemProxy()).thenReturn(true);
         when(configuration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/");
+        when(configuration.getConTimeout()).thenReturn("1000");
+        when(configuration.getReadTimeout()).thenReturn("1000");
 
         when(env.containsProperty(anyString())).thenReturn(true);
         when(env.getProperty(anyString())).thenReturn("localhost-proxy", "3129", "HTTP", "null", "null");
@@ -182,6 +188,8 @@ public class CalloutHttpPolicyTest {
 
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
         when(configuration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/");
+        when(configuration.getConTimeout()).thenReturn("1000");
+        when(configuration.getReadTimeout()).thenReturn("1000");
         when(configuration.getVariables()).thenReturn(Collections.singletonList(
                 new Variable("my-var", "{#jsonPath(#calloutResponse.content, '$.key')}")));
 
@@ -218,6 +226,8 @@ public class CalloutHttpPolicyTest {
 
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
         when(configuration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/{#request.params['param']}");
+        when(configuration.getConTimeout()).thenReturn("1000");
+        when(configuration.getReadTimeout()).thenReturn("1000");
         when(configuration.getVariables()).thenReturn(Collections.singletonList(
                 new Variable("my-var", "{#jsonPath(#calloutResponse.content, '$.key')}")));
 
@@ -246,6 +256,8 @@ public class CalloutHttpPolicyTest {
 
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
         when(configuration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/");
+        when(configuration.getConTimeout()).thenReturn("1000");
+        when(configuration.getReadTimeout()).thenReturn("1000");
         when(configuration.isExitOnError()).thenReturn(true);
         when(configuration.getErrorCondition()).thenReturn("{#calloutResponse.status >= 400 and #calloutResponse.status <= 599}");
         when(configuration.getErrorContent()).thenReturn("This is an error content");
@@ -275,6 +287,8 @@ public class CalloutHttpPolicyTest {
 
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
         when(configuration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/");
+        when(configuration.getConTimeout()).thenReturn("1000");
+        when(configuration.getReadTimeout()).thenReturn("1000");
         when(configuration.getVariables()).thenReturn(Collections.singletonList(
                 new Variable("my-headers", "{#jsonPath(#calloutResponse.headers, '$.Header')}")));
 
@@ -294,7 +308,28 @@ public class CalloutHttpPolicyTest {
     @Test
     public void shouldIgnoreConnectionError() throws Exception {
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
+        when(configuration.getConTimeout()).thenReturn("60000");
+        when(configuration.getReadTimeout()).thenReturn("60000");
         when(configuration.isExitOnError()).thenReturn(false);
+        when(configuration.getUrl()).thenReturn("http://"+ UUID.randomUUID() +":8080/");
+
+        final CountDownLatch lock = new CountDownLatch(1);
+        this.policyChain = spy(new CountDownPolicyChain(lock));
+
+        new CalloutHttpPolicy(configuration).onRequest(request, response, executionContext, policyChain);
+
+        lock.await(61, TimeUnit.SECONDS); // vertx DEFAULT_CONNECT_TIMEOUT is 60 seconds
+
+        verify(policyChain, never()).failWith(any());
+        verify(policyChain).doNext(any(), any());
+    }
+
+    @Test
+    public void shouldIgnoreExceptions() throws Exception {
+        when(configuration.getMethod()).thenReturn(HttpMethod.GET);
+        when(configuration.getConTimeout()).thenReturn("60000");
+        when(configuration.getReadTimeout()).thenReturn("60000");
+        when(configuration.ignoreTimeouts()).thenReturn(true);
         when(configuration.getUrl()).thenReturn("http://"+ UUID.randomUUID() +":8080/");
 
         final CountDownLatch lock = new CountDownLatch(1);

--- a/src/test/java/io/gravitee/policy/CalloutHttpPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/CalloutHttpPolicyTest.java
@@ -325,11 +325,11 @@ public class CalloutHttpPolicyTest {
     }
 
     @Test
-    public void shouldIgnoreExceptions() throws Exception {
+    public void shouldContinueOnTimeout() throws Exception {
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
         when(configuration.getConTimeout()).thenReturn("60000");
         when(configuration.getReadTimeout()).thenReturn("60000");
-        when(configuration.ignoreTimeouts()).thenReturn(true);
+        when(configuration.isContinueOnTimeout()).thenReturn(true);
         when(configuration.getUrl()).thenReturn("http://"+ UUID.randomUUID() +":8080/");
 
         final CountDownLatch lock = new CountDownLatch(1);


### PR DESCRIPTION
Closes https://github.com/gravitee-io/issues/issues/4727


The default behavior of the plugin works very well on requests that need to fail in any error situation:  ExitOnError.
But we have an use case, where we have to respect the error, in case of returns like 401, 403, 422, but in case of timeouts exceptions, the plugin needs to keep the flow continues, that is, only the ExitOnError option does not meet this case, and we also need very short wait times, if there is no response from the service in less than 2 seconds, let the request continue, that is, I only stop the request in cases of specific http code errors.

If this code that I sent, has the quality needed by gravitee, will be nice for us, we don't need to creae owr plugin.
