### PR TITLE
refactor: use common vertx proxy options factory

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,6 +34,17 @@ processing.
 The result of the callout is placed in a variable called `calloutResponse` and is only available during policy
 execution. If no variable is configured the result of the callout is no longer available.
 
+== Compatibility with APIM
+
+|===
+|Plugin version | APIM version
+
+|2.x and upper                  | 3.18.x to latest
+|1.15.x and upper               | 3.15.x to 3.17.x
+|1.13.x to 1.14.x               | 3.10.x to 3.14.x
+|Up to 1.12.x                   | Up to 3.9.x
+|===
+
 == Configuration
 
 |===

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,9 @@
     <properties>
         <gravitee-bom.version>1.0</gravitee-bom.version>
         <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
+        <gravitee-node.version>1.23.0</gravitee-node.version>
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.25.0</gravitee-common.version>
+        <gravitee-common.version>1.26.1</gravitee-common.version>
         <gravitee-expression-language.version>1.8.0</gravitee-expression-language.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
@@ -66,6 +67,13 @@
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
             <version>${gravitee-gateway-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <version>${gravitee-node.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/test/java/io/gravitee/policy/CalloutHttpPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/CalloutHttpPolicyTest.java
@@ -35,6 +35,7 @@ import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.RequestWrapper;
 import io.gravitee.gateway.api.Response;
+import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.callout.CalloutHttpPolicy;
@@ -53,7 +54,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.core.env.Environment;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -80,13 +80,13 @@ public class CalloutHttpPolicyTest {
     private CalloutHttpPolicyConfiguration configuration;
 
     @Mock
-    private Environment env;
+    private Configuration nodeConfiguration;
 
     @Before
     public void init() {
-        reset(configuration, executionContext, request, response, env);
+        reset(configuration, executionContext, request, response, nodeConfiguration);
         when(executionContext.getComponent(Vertx.class)).thenReturn(Vertx.vertx());
-        when(executionContext.getComponent(Environment.class)).thenReturn(env);
+        when(executionContext.getComponent(io.gravitee.node.api.configuration.Configuration.class)).thenReturn(nodeConfiguration);
         when(executionContext.getTemplateEngine()).thenReturn(new SpelTemplateEngineFactory().templateEngine());
 
         Request request = new RequestWrapper(mock(Request.class)) {
@@ -147,9 +147,6 @@ public class CalloutHttpPolicyTest {
         when(configuration.isUseSystemProxy()).thenReturn(true);
         when(configuration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/");
 
-        when(env.containsProperty(anyString())).thenReturn(true);
-        when(env.getProperty(anyString())).thenReturn("localhost-proxy", "3129", "HTTP", "null", "null");
-
         final CountDownLatch lock = new CountDownLatch(1);
         this.policyChain = spy(new CountDownPolicyChain(lock));
 
@@ -158,11 +155,11 @@ public class CalloutHttpPolicyTest {
         lock.await(1000, TimeUnit.MILLISECONDS);
 
         verify(policyChain).doNext(request, response);
-        verify(env).getProperty("system.proxy.port");
-        verify(env).getProperty("system.proxy.type");
-        verify(env).getProperty("system.proxy.host");
-        verify(env).getProperty("system.proxy.username");
-        verify(env).getProperty("system.proxy.password");
+        verify(nodeConfiguration).getProperty("system.proxy.port");
+        verify(nodeConfiguration).getProperty("system.proxy.type");
+        verify(nodeConfiguration).getProperty("system.proxy.host");
+        verify(nodeConfiguration).getProperty("system.proxy.username");
+        verify(nodeConfiguration).getProperty("system.proxy.password");
     }
 
     @Test


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7739

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-refactor-use-commong-proxy-options-factory-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-callout-http/2.0.0-refactor-use-commong-proxy-options-factory-SNAPSHOT/gravitee-policy-callout-http-2.0.0-refactor-use-commong-proxy-options-factory-SNAPSHOT.zip)
  <!-- Version placeholder end -->
