### PR TITLE
test: test policy with APIM Gateway SDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@2.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -30,35 +30,27 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.1</version>
+        <version>20.2</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>1.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
-        <gravitee-node.version>1.23.0</gravitee-node.version>
-        <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-bom.version>2.5</gravitee-bom.version>
         <gravitee-common.version>1.26.1</gravitee-common.version>
-        <gravitee-expression-language.version>1.8.0</gravitee-expression-language.version>
+        <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
+        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
+        <gravitee-node.version>1.24.1</gravitee-node.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
-        <junit-jupiter.version>5.8.2</junit-jupiter.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
                 <groupId>io.gravitee</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,26 +30,35 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>20.1</version>
     </parent>
 
     <properties>
         <gravitee-bom.version>1.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
         <gravitee-node.version>1.23.0</gravitee-node.version>
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
         <gravitee-common.version>1.26.1</gravitee-common.version>
         <gravitee-expression-language.version>1.8.0</gravitee-expression-language.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
+        <junit-jupiter.version>5.8.2</junit-jupiter.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- Import bom to properly inherit all dependencies -->
             <dependency>
                 <groupId>io.gravitee</groupId>
@@ -113,24 +122,29 @@
 
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
-            <version>2.30.0</version>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/io/gravitee/policy/CalloutHttpPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/CalloutHttpPolicyIntegrationTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.Api;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.callout.CalloutHttpPolicy;
+import io.gravitee.policy.callout.configuration.CalloutHttpPolicyConfiguration;
+import io.reactivex.observers.TestObserver;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+class CalloutHttpPolicyIntegrationTest extends AbstractPolicyTest<CalloutHttpPolicy, CalloutHttpPolicyConfiguration> {
+
+    public static final String LOCALHOST = "localhost:";
+    public static final String CALLOUT_BASE_URL = LOCALHOST + "8089";
+
+    @RegisterExtension
+    static WireMockExtension calloutServer = WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+    /**
+     * Override Callout policy URL to use the dynamic port from {@link CalloutHttpPolicyIntegrationTest#calloutServer}
+     * @param api is the api to apply this function code
+     */
+    @Override
+    public void configureApi(Api api) {
+        api
+            .getFlows()
+            .forEach(flow -> {
+                flow
+                    .getPre()
+                    .stream()
+                    .filter(step -> policyName().equals(step.getPolicy()))
+                    .forEach(step ->
+                        step.setConfiguration(step.getConfiguration().replace(CALLOUT_BASE_URL, LOCALHOST + calloutServer.getPort()))
+                    );
+            });
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put("copy-callout-attribute", PolicyBuilder.build("copy-callout-attribute", CopyCalloutAttributePolicy.class));
+    }
+
+    @Test
+    @DisplayName("Should do callout and set response as attribute")
+    @DeployApi("/apis/callout-http.json")
+    void shouldDoCalloutAndSetResponseAsAttribute(WebClient client) throws Exception {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend")));
+        calloutServer.stubFor(get("/callout").willReturn(ok("response from callout")));
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                assertThat(response.bodyAsString()).isEqualTo("response from callout");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint")));
+        calloutServer.verify(getRequestedFor(urlPathEqualTo("/callout")).withHeader("X-Callout", equalTo("calloutHeader")));
+    }
+
+    @Test
+    @DisplayName("Should do callout Fire and Forget")
+    @DeployApi("/apis/callout-http-fire-and-forget.json")
+    void shouldDoCalloutFireAndForget(WebClient client) throws Exception {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend")));
+        calloutServer.stubFor(get("/callout").willReturn(ok("response from callout")));
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                assertThat(response.bodyAsString()).isEqualTo(CopyCalloutAttributePolicy.NO_CALLOUT_CONTENT_ATTRIBUTE);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint")));
+        calloutServer.verify(getRequestedFor(urlPathEqualTo("/callout")).withHeader("X-Callout", equalTo("calloutHeader")));
+    }
+
+    @Test
+    @DisplayName("Should do callout on invalid target and answer custom response")
+    @DeployApi("/apis/callout-http-invalid-target.json")
+    void shouldDoCalloutInvalidTarget(WebClient client) throws Exception {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend")));
+        calloutServer.stubFor(get("/callout").willReturn(aResponse().withStatus(501).withBody("callout backend not implemented")));
+
+        final TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(HttpStatusCode.NOT_IMPLEMENTED_501);
+                assertThat(response.bodyAsString()).isEqualTo("errorContent");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
+        calloutServer.verify(getRequestedFor(urlPathEqualTo("/callout")).withHeader("X-Callout", equalTo("calloutHeader")));
+    }
+}

--- a/src/test/java/io/gravitee/policy/CopyCalloutAttributePolicy.java
+++ b/src/test/java/io/gravitee/policy/CopyCalloutAttributePolicy.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.stream.BufferedReadWriteStream;
+import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
+import io.gravitee.policy.api.annotations.OnResponseContent;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class CopyCalloutAttributePolicy {
+
+    public static final String NO_CALLOUT_CONTENT_ATTRIBUTE = "noCalloutContent";
+
+    @OnResponseContent
+    public ReadWriteStream<Buffer> onResponseContent(ExecutionContext context) {
+        return new BufferedReadWriteStream() {
+            @Override
+            public SimpleReadWriteStream<Buffer> write(Buffer content) {
+                return this;
+            }
+
+            @Override
+            public void end() {
+                String content = NO_CALLOUT_CONTENT_ATTRIBUTE;
+                final Object calloutContent = context.getAttribute("calloutContent");
+                if (calloutContent != null) {
+                    content = calloutContent.toString();
+                }
+                super.write(Buffer.buffer(content));
+                super.end();
+            }
+        };
+    }
+}

--- a/src/test/resources/apis/callout-http-fire-and-forget.json
+++ b/src/test/resources/apis/callout-http-fire-and-forget.json
@@ -1,0 +1,60 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Callout HTTP",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-http-callout",
+          "configuration": {
+            "method": "GET",
+            "url": "http://localhost:8089/callout",
+            "scope": "REQUEST",
+            "headers": [
+              {
+                "name": "X-Callout",
+                "value": "calloutHeader"
+              }
+            ],
+            "fireAndForget": true
+          }
+        }
+      ],
+      "post": [
+        {
+          "name": "Copy Callout Attribute",
+          "description": "",
+          "enabled": true,
+          "policy": "copy-callout-attribute",
+          "configuration": {}
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/apis/callout-http-invalid-target.json
+++ b/src/test/resources/apis/callout-http-invalid-target.json
@@ -1,0 +1,55 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Callout HTTP",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-http-callout",
+          "configuration": {
+            "method": "GET",
+            "url": "http://localhost:8089/callout",
+            "scope": "REQUEST",
+            "headers": [
+              {
+                "name": "X-Callout",
+                "value": "calloutHeader"
+              }
+            ],
+            "exitOnError": true,
+            "errorCondition": "{#calloutResponse.status >= 400 and #calloutResponse.status <= 599}",
+            "errorStatusCode": "501",
+            "errorContent": "errorContent"
+          }
+        }
+      ],
+      "post": []
+    }
+  ]
+}

--- a/src/test/resources/apis/callout-http.json
+++ b/src/test/resources/apis/callout-http.json
@@ -1,0 +1,65 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Callout HTTP",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-http-callout",
+          "configuration": {
+            "method": "GET",
+            "url": "http://localhost:8089/callout",
+            "scope": "REQUEST",
+            "headers": [
+              {
+                "name": "X-Callout",
+                "value": "calloutHeader"
+              }
+            ],
+            "variables": [
+              {
+                "name": "calloutContent",
+                "value": "{#jsonPath(#calloutResponse.content, '$')}"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [
+        {
+          "name": "Copy Callout Attribute",
+          "description": "",
+          "enabled": true,
+          "policy": "copy-callout-attribute",
+          "configuration": {}
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7718

**Description**

Test policy with Gateway Testing SDK

- [x]  Should do callout and set response at attribute
- [x]  Should do callout Fire and Forget
- [x]  Should do callout and use custom response on invalid target
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-callout-http/2.0.0/gravitee-policy-callout-http-2.0.0.zip)
  <!-- Version placeholder end -->
