### PR TITLE
Call callout endpoint with proper body when it contains accents 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,11 @@
     </parent>
 
     <properties>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.3</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-bom.version>2.5</gravitee-bom.version>
         <gravitee-common.version>1.26.1</gravitee-common.version>
         <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
-        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.37.0</gravitee-gateway-api.version>
         <gravitee-node.version>1.24.1</gravitee-node.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>

--- a/src/main/java/io/gravitee/policy/callout/CalloutHttpPolicy.java
+++ b/src/main/java/io/gravitee/policy/callout/CalloutHttpPolicy.java
@@ -244,7 +244,8 @@ public class CalloutHttpPolicy {
                 // Check the resolved body before trying to send it.
                 if (body != null && !body.isEmpty()) {
                     httpClientRequest.headers().remove(HttpHeaders.TRANSFER_ENCODING);
-                    httpClientRequest.putHeader(HttpHeaders.CONTENT_LENGTH, Integer.toString(body.length()));
+                    // Removing Content-Length header to let VertX automatically set it correctly
+                    httpClientRequest.headers().remove(HttpHeaders.CONTENT_LENGTH);
                     futureResponse = httpClientRequest.send(Buffer.buffer(body));
                 } else {
                     futureResponse = httpClientRequest.send();

--- a/src/test/resources/apis/callout-http-post-with-accents.json
+++ b/src/test/resources/apis/callout-http-post-with-accents.json
@@ -1,0 +1,45 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "POST"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Callout HTTP",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-http-callout",
+          "configuration": {
+            "method": "POST",
+            "url": "http://localhost:8089/callout",
+            "scope": "REQUEST_CONTENT",
+            "body": "{#request.content}"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8109

Should also fix https://github.com/gravitee-io/issues/issues/8235

**Description**

- Bump `gravitee-gateway-api` and gateway test SDK
- Call callout endpoint with the proper body when it contains accents -> Same pb as https://github.com/gravitee-io/issues/issues/5184, I applied the same fix
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-8109-handle-accents-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-callout-http/2.0.1-8109-handle-accents-SNAPSHOT/gravitee-policy-callout-http-2.0.1-8109-handle-accents-SNAPSHOT.zip)
  <!-- Version placeholder end -->
