### PR TITLE
Update Renovate config to reduce the number of PRs and so notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default
-*       @gravitee-io/apim @gravitee-io/archi @gravitee-io/am
+*       @gravitee-io/apim @gravitee-io/am

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,19 @@
 {
   "extends": [
-    "config:base",
-    "schedule:earlyMondays"
+    "config:base"
   ],
-  "prConcurrentLimit": 3,
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["orb"],
       "rangeStrategy": "replace"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
     }
   ]
 }


### PR DESCRIPTION
**Issue**

NA

**Description**

Apply the same renovate configuration as `policy-xslt` to ensure everything is ok when applied to another plugin
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-callout-http/2.0.1/gravitee-policy-callout-http-2.0.1.zip)
  <!-- Version placeholder end -->
