### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,9 @@ execution. If no variable is configured the result of the callout is no longer a
 |===
 |Plugin version | APIM version
 
-|2.x and upper                  | 3.18.x to latest
+|4.x                            | 4.4.x to latest
+|3.x                            | 4.0.x to 4.3.x
+|2.x                            | 3.18.x to 3.20.x
 |1.15.x and upper               | 3.15.x to 3.17.x
 |1.13.x to 1.14.x               | 3.10.x to 3.14.x
 |Up to 1.12.x                   | Up to 3.9.x

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-callout-http</artifactId>
-    <version>3.0.0</version>
+    <version>4.0.0</version>
 
     <name>Gravitee.io APIM - Policy - Callout HTTP</name>
     <description>Invoke an HTTP(S) URL and place a subset or all of the content in one or more variables of the request execution context</description>
@@ -34,16 +34,17 @@
     </parent>
 
     <properties>
-        <gravitee-apim-gateway-tests-sdk.version>4.1.5</gravitee-apim-gateway-tests-sdk.version>
-        <gravitee-bom.version>6.0.47</gravitee-bom.version>
-        <gravitee-common.version>3.4.1</gravitee-common.version>
+        <gravitee-bom.version>7.0.23</gravitee-bom.version>
+        <gravitee-common.version>4.4.0</gravitee-common.version>
         <gravitee-expression-language.version>3.2.0</gravitee-expression-language.version>
-        <gravitee-gateway-api.version>3.1.0</gravitee-gateway-api.version>
-        <gravitee-node.version>4.8.7</gravitee-node.version>
+        <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
+        <gravitee-node.version>5.18.3</gravitee-node.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-apim.version>4.4.0</gravitee-apim.version>
 
-        <gravitee-reactor-message.version>1.0.3</gravitee-reactor-message.version>
-        <gravitee-entrypoint-sse.version>4.0.2</gravitee-entrypoint-sse.version>
+
+        <gravitee-reactor-message.version>3.0.0</gravitee-reactor-message.version>
+        <gravitee-entrypoint-sse.version>4.1.0</gravitee-entrypoint-sse.version>
 
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
@@ -63,6 +64,13 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node</artifactId>
+                <version>${gravitee-node.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -78,6 +86,12 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
+            <version>${gravitee-node.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-vertx</artifactId>
             <version>${gravitee-node.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -130,25 +144,25 @@
         <dependency>
             <groupId>io.gravitee.apim.gateway</groupId>
             <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
-            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <version>${gravitee-apim.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
             <artifactId>gravitee-apim-plugin-entrypoint-http-proxy</artifactId>
-            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <version>${gravitee-apim.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.gravitee.apim.plugin.endpoint</groupId>
             <artifactId>gravitee-apim-plugin-endpoint-http-proxy</artifactId>
-            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <version>${gravitee-apim.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.gravitee.apim.plugin.endpoint</groupId>
             <artifactId>gravitee-apim-plugin-endpoint-mock</artifactId>
-            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <version>${gravitee-apim.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/gravitee/policy/callout/CalloutHttpPolicy.java
+++ b/src/main/java/io/gravitee/policy/callout/CalloutHttpPolicy.java
@@ -15,13 +15,13 @@
  */
 package io.gravitee.policy.callout;
 
-import static io.gravitee.common.util.VertxProxyOptionsUtils.setSystemProxy;
 import static java.util.stream.Collectors.toList;
 
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.policy.Policy;
 import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.vertx.proxy.VertxProxyOptionsUtils;
 import io.gravitee.policy.callout.configuration.CalloutHttpPolicyConfiguration;
 import io.gravitee.policy.callout.configuration.HttpHeader;
 import io.gravitee.policy.v3.callout.CalloutHttpPolicyV3;
@@ -144,7 +144,7 @@ public class CalloutHttpPolicy extends CalloutHttpPolicyV3 implements Policy {
         if (configuration.isUseSystemProxy()) {
             Configuration configuration = ctx.getComponent(Configuration.class);
             try {
-                setSystemProxy(options, configuration);
+                options.setProxyOptions(VertxProxyOptionsUtils.buildProxyOptions(configuration));
             } catch (IllegalStateException e) {
                 log.warn(
                     "CalloutHttp requires a system proxy to be defined but some configurations are missing or not well defined: {}. Ignoring proxy",

--- a/src/main/java/io/gravitee/policy/v3/callout/CalloutHttpPolicyV3.java
+++ b/src/main/java/io/gravitee/policy/v3/callout/CalloutHttpPolicyV3.java
@@ -15,8 +15,6 @@
  */
 package io.gravitee.policy.v3.callout;
 
-import static io.gravitee.common.util.VertxProxyOptionsUtils.setSystemProxy;
-
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
@@ -27,6 +25,7 @@ import io.gravitee.gateway.api.stream.BufferedReadWriteStream;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
 import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
 import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.vertx.proxy.VertxProxyOptionsUtils;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.api.annotations.OnRequest;
@@ -203,7 +202,7 @@ public class CalloutHttpPolicyV3 {
             if (configuration.isUseSystemProxy()) {
                 Configuration configuration = context.getComponent(Configuration.class);
                 try {
-                    setSystemProxy(options, configuration);
+                    options.setProxyOptions(VertxProxyOptionsUtils.buildProxyOptions(configuration));
                 } catch (IllegalStateException e) {
                     LOGGER.warn(
                         "CalloutHttp requires a system proxy to be defined but some configurations are missing or not well defined: {}. Ignoring proxy",


### PR DESCRIPTION
BREAKING CHANGE: require APIM 4.4.x

**Issue**

https://gravitee.atlassian.net/browse/APIM-6174

**Description**

Updated APIM version VertxProxyOptionsUtils was moved to gravitee-node

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-callout-http/4.0.0/gravitee-policy-callout-http-4.0.0.zip)
  <!-- Version placeholder end -->
