### PR TITLE
fix: properly handle fire and forget in V4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
         <gravitee-reactor-message.version>3.0.0</gravitee-reactor-message.version>
         <gravitee-entrypoint-sse.version>4.1.0</gravitee-entrypoint-sse.version>
 
+        <awaitility.version>4.2.1</awaitility.version>
+
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
@@ -185,6 +187,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/policy/callout/CalloutHttpPolicy.java
+++ b/src/main/java/io/gravitee/policy/callout/CalloutHttpPolicy.java
@@ -66,6 +66,14 @@ public class CalloutHttpPolicy extends CalloutHttpPolicyV3 implements Policy {
     }
 
     private Completable doCallOut(HttpExecutionContext ctx) {
+        if (configuration.isFireAndForget()) {
+            return Completable.fromRunnable(() -> executeCallOut(ctx).onErrorComplete().subscribe());
+        } else {
+            return executeCallOut(ctx);
+        }
+    }
+
+    private Completable executeCallOut(HttpExecutionContext ctx) {
         var templateEngine = ctx.getTemplateEngine();
         var vertx = ctx.getComponent(Vertx.class);
 

--- a/src/test/java/io/gravitee/policy/callout/AbstractV4EngineTest.java
+++ b/src/test/java/io/gravitee/policy/callout/AbstractV4EngineTest.java
@@ -40,6 +40,7 @@ import io.gravitee.policy.callout.configuration.CalloutHttpPolicyConfiguration;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 @GatewayTest
@@ -49,6 +50,11 @@ public class AbstractV4EngineTest extends AbstractPolicyTest<CalloutHttpPolicy, 
 
     @RegisterExtension
     static WireMockExtension calloutServer = WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+    @BeforeEach
+    public void cleanStub() {
+        calloutServer.resetAll();
+    }
 
     @Override
     public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {

--- a/src/test/java/io/gravitee/policy/callout/CalloutHttpPolicyV4Test.java
+++ b/src/test/java/io/gravitee/policy/callout/CalloutHttpPolicyV4Test.java
@@ -25,6 +25,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static io.gravitee.policy.v3.callout.CalloutHttpPolicyV3.CALLOUT_EXIT_ON_ERROR;
 import static io.gravitee.policy.v3.callout.CalloutHttpPolicyV3.CALLOUT_HTTP_ERROR;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static test.RequestBuilder.aRequest;
@@ -341,11 +342,10 @@ class CalloutHttpPolicyV4Test {
             )
                 .onRequest(ctx)
                 .test()
-                .awaitDone(30, TimeUnit.SECONDS)
                 .assertComplete();
 
             assertThat(ctx.getAttributes()).isEmpty();
-            wiremock.verify(getRequestedFor(urlPathEqualTo("/")));
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> wiremock.verify(getRequestedFor(urlPathEqualTo("/"))));
         }
 
         @Test
@@ -662,11 +662,10 @@ class CalloutHttpPolicyV4Test {
             )
                 .onResponse(ctx)
                 .test()
-                .awaitDone(30, TimeUnit.SECONDS)
                 .assertComplete();
 
             assertThat(ctx.getAttributes()).isEmpty();
-            wiremock.verify(getRequestedFor(urlPathEqualTo("/")));
+            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> wiremock.verify(getRequestedFor(urlPathEqualTo("/"))));
         }
 
         @Test

--- a/src/test/resources/apis/v4/proxy/response-callout-http-el-support.json
+++ b/src/test/resources/apis/v4/proxy/response-callout-http-el-support.json
@@ -57,7 +57,7 @@
                             }
                         ],
                         "body": "{#request.headers['X-Body'][0]}",
-                        "fireAndForget": true
+                        "fireAndForget": false
                     }
                 },
                 {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-6362

**Description**

Call out request in V4 was not done in background when fire and forget was enabled.
**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.1-apim-6362-fix-fire-forget-mode-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-callout-http/4.0.1-apim-6362-fix-fire-forget-mode-SNAPSHOT/gravitee-policy-callout-http-4.0.1-apim-6362-fix-fire-forget-mode-SNAPSHOT.zip)
  <!-- Version placeholder end -->
