### PR TITLE
fix: handle fire and forget

### DIFF
--- a/src/test/java/io/gravitee/policy/callout/CalloutHttpPolicyV4IntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/callout/CalloutHttpPolicyV4IntegrationTest.java
@@ -82,7 +82,7 @@ class CalloutHttpPolicyV4IntegrationTest {
         @ValueSource(strings = { "/proxy-request-fire-and-forget", "/proxy-response-fire-and-forget" })
         void should_do_callout_with_fire_and_forget_and_do_nothing_with_callout_response(String apiEndpoint, HttpClient client) {
             wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend")));
-            calloutServer.stubFor(get("/callout").willReturn(ok("response from callout").withFixedDelay(8000)));
+            calloutServer.stubFor(get("/callout").willReturn(ok("response from callout")));
 
             var obs = client
                 .rxRequest(HttpMethod.GET, apiEndpoint)

--- a/src/test/java/io/gravitee/policy/callout/CalloutHttpPolicyV4Test.java
+++ b/src/test/java/io/gravitee/policy/callout/CalloutHttpPolicyV4Test.java
@@ -342,6 +342,7 @@ class CalloutHttpPolicyV4Test {
             )
                 .onRequest(ctx)
                 .test()
+                .awaitDone(30, TimeUnit.SECONDS)
                 .assertComplete();
 
             assertThat(ctx.getAttributes()).isEmpty();
@@ -662,6 +663,7 @@ class CalloutHttpPolicyV4Test {
             )
                 .onResponse(ctx)
                 .test()
+                .awaitDone(30, TimeUnit.SECONDS)
                 .assertComplete();
 
             assertThat(ctx.getAttributes()).isEmpty();


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9355

**Description**

handled the fire and forget check
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.2-APIM-9355-Http-Callout-policy-does-not-work-with-V4-emulation-and-Fire-and-forget-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-callout-http/4.0.2-APIM-9355-Http-Callout-policy-does-not-work-with-V4-emulation-and-Fire-and-forget-SNAPSHOT/gravitee-policy-callout-http-4.0.2-APIM-9355-Http-Callout-policy-does-not-work-with-V4-emulation-and-Fire-and-forget-SNAPSHOT.zip)
  <!-- Version placeholder end -->
