### PR TITLE
fix: performance improvement : make http connection pool configurable for http callout policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ system:
 | Exit on error<br>`exitOnError`| boolean| ✅| | Terminate the request if the error condition is true.|
 | Fire & forget<br>`fireAndForget`| boolean|  | | Make the HTTP call without expecting any response. When activating this mode, context variables and exit on error are useless.|
 | Request Headers<br>`headers`| array|  | | <br/>See "Request Headers" section.|
+| `http`| object|  | | <br/>See "" section.|
 | HTTP Method<br>`method`| enum (string)| ✅| `GET`| HTTP method to invoke the endpoint.<br>Values: `GET` `POST` `PUT` `DELETE` `PATCH` `HEAD` `CONNECT` `OPTIONS` `TRACE`|
 | URL<br>`url`| string| ✅| | |
 | Use system proxy<br>`useSystemProxy`| boolean|  | | Use the system proxy configured by your administrator.|
@@ -113,6 +114,12 @@ system:
 |:----------------------|:-----------------------|:----------:|:-------------|
 | Name<br>`name`| string|  | |
 | Value<br>`value`| string|  | |
+
+
+####  (Object)
+| Name <br>`json name`  | Type <br>`constraint`  | Mandatory  | Default  | Description  |
+|:----------------------|:-----------------------|:----------:|:---------|:-------------|
+| Max concurrent connections<br>`maxConcurrentConnections`| integer|  | `20`| The maximum concurrent connections triggered by the policy at the same time.|
 
 
 #### Context variables (Array)

--- a/src/main/java/io/gravitee/policy/callout/CalloutHttpPolicy.java
+++ b/src/main/java/io/gravitee/policy/callout/CalloutHttpPolicy.java
@@ -232,14 +232,18 @@ public class CalloutHttpPolicy extends CalloutHttpPolicyV3 implements HttpPolicy
      * @param ctx The context to get Vertx component
      * @return Built or existing HttpClient
      */
-    private HttpClient getHttpClient(BaseExecutionContext ctx) {
+    HttpClient getHttpClient(BaseExecutionContext ctx) {
         if (this.httpClient == null) {
             synchronized (this) {
                 if (this.httpClient == null) {
                     // SSL options (trustAll, verifyHost) are set at client level but only applied per-request
                     // when the URL scheme is HTTPS. Vertx's RequestOptions.setAbsoluteURI() overrides the client
                     // SSL setting based on the actual URL scheme, so HTTP requests are not affected.
-                    var options = new HttpClientOptions().setSsl(true).setTrustAll(true).setVerifyHost(false);
+                    var options = new HttpClientOptions()
+                        .setSsl(true)
+                        .setTrustAll(true)
+                        .setVerifyHost(false)
+                        .setMaxPoolSize(configuration.getHttpOptions().getMaxConcurrentConnections());
 
                     if (configuration.isUseSystemProxy()) {
                         Configuration config = ctx.getComponent(Configuration.class);

--- a/src/main/java/io/gravitee/policy/callout/configuration/CalloutHttpPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/callout/configuration/CalloutHttpPolicyConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.policy.callout.configuration;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.policy.api.PolicyConfiguration;
@@ -64,4 +65,8 @@ public class CalloutHttpPolicyConfiguration implements PolicyConfiguration {
     private String errorContent;
 
     private boolean useSystemProxy;
+
+    @Builder.Default
+    @JsonProperty("http")
+    private HttpClientOptions httpOptions = new HttpClientOptions();
 }

--- a/src/main/java/io/gravitee/policy/callout/configuration/HttpClientOptions.java
+++ b/src/main/java/io/gravitee/policy/callout/configuration/HttpClientOptions.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.callout.configuration;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class HttpClientOptions implements Serializable {
+
+    private int maxConcurrentConnections = 20;
+}

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -284,6 +284,17 @@
                     }
                 ]
             }
+        },
+        "http": {
+            "type": "object",
+            "properties": {
+                "maxConcurrentConnections": {
+                    "title": "Max concurrent connections",
+                    "description": "The maximum concurrent connections triggered by the policy at the same time.",
+                    "type": "integer",
+                    "default": 20
+                }
+            }
         }
     },
     "required": ["url", "method", "exitOnError"]

--- a/src/test/java/io/gravitee/policy/callout/CalloutHttpPolicyV4Test.java
+++ b/src/test/java/io/gravitee/policy/callout/CalloutHttpPolicyV4Test.java
@@ -40,6 +40,7 @@ import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailur
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.policy.callout.configuration.CalloutHttpPolicyConfiguration;
+import io.gravitee.policy.callout.configuration.HttpClientOptions;
 import io.gravitee.policy.callout.configuration.Variable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.processors.ReplayProcessor;
@@ -55,6 +56,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import test.ExecutionContextBuilder;
 import test.stub.KafkaMessageRequestStub;
 import test.stub.KafkaMessageResponseStub;
@@ -806,6 +808,44 @@ class CalloutHttpPolicyV4Test {
             await()
                 .atMost(10, TimeUnit.SECONDS)
                 .untilAsserted(() -> wiremock.verify(recordsCount, getRequestedFor(urlPathEqualTo("/"))));
+        }
+    }
+
+    @Nested
+    class GetHttpClient {
+
+        @Test
+        void should_set_max_pool_size_from_configuration() {
+            var mockVertx = mock(Vertx.class);
+            var mockHttpClient = mock(io.vertx.rxjava3.core.http.HttpClient.class);
+            var optionsCaptor = ArgumentCaptor.forClass(io.vertx.core.http.HttpClientOptions.class);
+            when(mockVertx.createHttpClient(optionsCaptor.capture())).thenReturn(mockHttpClient);
+
+            var ctx = new ExecutionContextBuilder().withComponent(Vertx.class, mockVertx).request(aRequest().build()).build();
+
+            policy(
+                CalloutHttpPolicyConfiguration.builder()
+                    .url("http://localhost/")
+                    .method(HttpMethod.GET)
+                    .httpOptions(new HttpClientOptions(10))
+                    .build()
+            ).getHttpClient(ctx);
+
+            assertThat(optionsCaptor.getValue().getMaxPoolSize()).isEqualTo(10);
+        }
+
+        @Test
+        void should_set_max_pool_size_default_value() {
+            var mockVertx = mock(Vertx.class);
+            var mockHttpClient = mock(io.vertx.rxjava3.core.http.HttpClient.class);
+            var optionsCaptor = ArgumentCaptor.forClass(io.vertx.core.http.HttpClientOptions.class);
+            when(mockVertx.createHttpClient(optionsCaptor.capture())).thenReturn(mockHttpClient);
+
+            var ctx = new ExecutionContextBuilder().withComponent(Vertx.class, mockVertx).request(aRequest().build()).build();
+
+            policy(CalloutHttpPolicyConfiguration.builder().url("http://localhost/").method(HttpMethod.GET).build()).getHttpClient(ctx);
+
+            assertThat(optionsCaptor.getValue().getMaxPoolSize()).isEqualTo(20);
         }
     }
 


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13322
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.1-apim-13322-v6-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-callout-http/6.0.1-apim-13322-v6-SNAPSHOT/gravitee-policy-callout-http-6.0.1-apim-13322-v6-SNAPSHOT.zip)
  <!-- Version placeholder end -->
