### PR TITLE
fix: multi-line editing for request body field

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -50,6 +50,7 @@
         "body": {
             "title": "Request body",
             "type": "string",
+            "format": "gio-code-editor",
             "x-schema-form": {
                 "type": "codemirror",
                 "codemirrorOptions": {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14283

**Description**

Render the HTTP Callout "Request body" field as a multi-line code editor in the v4 policy studio by adding `format: gio-code-editor` to the schema.

**Additional context**

Verified in the v4 policy studio: the Request body field now renders as a multi-line code editor.