### PR TITLE
fix: multi-line editing for request body field

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -50,6 +50,7 @@
         "body": {
             "title": "Request body",
             "type": "string",
+            "format": "gio-code-editor",
             "x-schema-form": {
                 "type": "codemirror",
                 "codemirrorOptions": {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14283

**Description**

Render the HTTP Callout "Request body" field as a multi-line code editor in the v4 policy studio by adding `format: gio-code-editor` to the schema.

**Additional context**

Verified in the v4 policy studio: the Request body field now renders as a multi-line code editor.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.4.2-apim-14283-5-4-1-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-callout-http/5.4.2-apim-14283-5-4-1-SNAPSHOT/gravitee-policy-callout-http-5.4.2-apim-14283-5-4-1-SNAPSHOT.zip)
  <!-- Version placeholder end -->
